### PR TITLE
Fix keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,17 +1,17 @@
 # Datatypes (KEYWORD1)
-TcType KEYWORD1
-TcAveraging KEYWORD1
-Nanoshield_Termopar KEYWORD1
+TcType	KEYWORD1
+TcAveraging	KEYWORD1
+Nanoshield_Termopar	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-begin KEYWORD2
-read KEYWORD2
-getExternal KEYWORD2
-getInternal KEYWORD2
-isExternalOutOfRange() KEYWORD2
-isInternalOutOfRange() KEYWORD2
-isOverUnderVoltage() KEYWORD2
-isOpen() KEYWORD2
-hasError() KEYWORD2
+begin	KEYWORD2
+read	KEYWORD2
+getExternal	KEYWORD2
+getInternal	KEYWORD2
+isExternalOutOfRange()	KEYWORD2
+isInternalOutOfRange()	KEYWORD2
+isOverUnderVoltage()	KEYWORD2
+isOpen()	KEYWORD2
+hasError()	KEYWORD2
 
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,10 +8,10 @@ begin	KEYWORD2
 read	KEYWORD2
 getExternal	KEYWORD2
 getInternal	KEYWORD2
-isExternalOutOfRange()	KEYWORD2
-isInternalOutOfRange()	KEYWORD2
-isOverUnderVoltage()	KEYWORD2
-isOpen()	KEYWORD2
-hasError()	KEYWORD2
+isExternalOutOfRange	KEYWORD2
+isInternalOutOfRange	KEYWORD2
+isOverUnderVoltage	KEYWORD2
+isOpen	KEYWORD2
+hasError	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
Fixes required to make this library's keywords be highlighted by the Arduino IDE

- Use correct keyword-identifier separator
- Remove parentheses from keywords